### PR TITLE
Send DNS lookups to Syslog, and limit log size

### DIFF
--- a/main/dns/stubs/named.conf.options.mas
+++ b/main/dns/stubs/named.conf.options.mas
@@ -117,7 +117,7 @@ logging {
 // query logging on (and off again) using command ‘rndc querylog’
 //
      channel queries_log {
-          file "/var/log/named/queries" versions 600 size 20m;
+          file "/var/log/named/queries" versions 10 size 80m;
           print-time yes;
           print-category yes;
           print-severity yes;
@@ -252,11 +252,11 @@ logging {
 // by default, make sure you add option ‘querylog no;’ - then you can toggle
 // query logging on (and off again) using command ‘rndc querylog’
 //
-     category queries { queries_log; };
+     category queries { queries_log; default_syslog; };
 //
 // This logging category will only emit messages at debug levels of 1 or
 // higher - it can be useful to troubleshoot problems where queries are
 // resulting in a SERVFAIL response.
 //
-     category query-errors {query-errors_log; };
+     category query-errors {query-errors_log; default_syslog; };
 };


### PR DESCRIPTION
Sending DNS queries to a remote logging server provides a great data source, which can reveal client PC's infected with malware (IOC's) or aid in detecting other threats.

Also limited query_log to 800mb storage (previous was 1.2GB, which seems like too much).

Overlooked these in my last PR!